### PR TITLE
Decouple camera observable refresh from video recording

### DIFF
--- a/capx/envs/simulators/robosuite_base.py
+++ b/capx/envs/simulators/robosuite_base.py
@@ -129,10 +129,17 @@ class RobosuiteBaseEnv(BaseEnv):
         return action
 
     def _do_robosuite_step(self, action: np.ndarray) -> None:
-        """Step robosuite with the given action, handling render skipping."""
+        """Step robosuite with the given action.
+
+        Camera observables are never refreshed here: they are rendered on demand
+        by get_observation(force_update=True). Gating them on ``_record_frames``
+        (as this used to) meant that with video recording off, perception saw the
+        RGB-D from reset() for the whole episode and grasped stale poses -- i.e.
+        --record-video silently changed task outcomes. viser debug views still
+        need a live render, so they keep the full step.
+        """
         sliced = action[:self._ACTION_SLICE] if self._ACTION_SLICE != 0 else action
-        need_render = (self._record_frames and self._sim_step_count % self._subsample_rate == 0) or hasattr(self, "viser_server")
-        if need_render:
+        if hasattr(self, "viser_server"):
             self.robosuite_env.step(sliced)
         else:
             self.robosuite_env.step(sliced, skip_render_images=True)

--- a/capx/envs/simulators/robosuite_cube_lift.py
+++ b/capx/envs/simulators/robosuite_cube_lift.py
@@ -172,7 +172,11 @@ class FrankaRobosuiteCubeLiftLowLevel(RobosuiteBaseEnv):
 
     def get_observation(self) -> dict[str, Any]:
         """Get observation in FrankaPickPlaceLowLevel format."""
-        robosuite_obs = self.robosuite_env._get_observations()
+        # force_update=True: camera observables are otherwise only refreshed by the
+        # occasional full robosuite step, which used to be gated on video recording.
+        # Without it, perception (SAM3/GraspNet) reuses the RGB-D from reset() and
+        # grasps stale object poses. See _do_robosuite_step in robosuite_base.py.
+        robosuite_obs = self.robosuite_env._get_observations(force_update=True)
         pose_dict = self._cube_pose_dict(robosuite_obs)
         cube_pose_array = np.stack(
             [

--- a/capx/envs/simulators/robosuite_cubes.py
+++ b/capx/envs/simulators/robosuite_cubes.py
@@ -198,7 +198,11 @@ class FrankaRobosuiteCubesLowLevel(RobosuiteBaseEnv):
 
     def get_observation(self) -> dict[str, Any]:
         """Get observation in FrankaPickPlaceLowLevel format."""
-        robosuite_obs = self.robosuite_env._get_observations()
+        # force_update=True: camera observables are otherwise only refreshed by the
+        # occasional full robosuite step, which used to be gated on video recording.
+        # Without it, perception (SAM3/GraspNet) reuses the RGB-D from reset() and
+        # grasps stale object poses. See _do_robosuite_step in robosuite_base.py.
+        robosuite_obs = self.robosuite_env._get_observations(force_update=True)
         pose_dict = self._cube_pose_dict(robosuite_obs)
         cube_pose_array = np.stack(
             [

--- a/capx/envs/simulators/robosuite_cubes_restack.py
+++ b/capx/envs/simulators/robosuite_cubes_restack.py
@@ -475,7 +475,11 @@ class FrankaRobosuiteCubesRestackLowLevel(RobosuiteBaseEnv):
 
     def get_observation(self) -> dict[str, Any]:
         """Get observation in FrankaPickPlaceLowLevel format."""
-        robosuite_obs = self.robosuite_env._get_observations()
+        # force_update=True: camera observables are otherwise only refreshed by the
+        # occasional full robosuite step, which used to be gated on video recording.
+        # Without it, perception (SAM3/GraspNet) reuses the RGB-D from reset() and
+        # grasps stale object poses. See _do_robosuite_step in robosuite_base.py.
+        robosuite_obs = self.robosuite_env._get_observations(force_update=True)
         pose_dict = self._cube_pose_dict(robosuite_obs)
         cube_pose_array = np.stack(
             [

--- a/capx/envs/simulators/robosuite_handover.py
+++ b/capx/envs/simulators/robosuite_handover.py
@@ -249,10 +249,9 @@ class RobosuiteHandoverEnv(BaseEnv):
             action = np.concatenate([robot0_action, robot1_action])
 
             # Step the environment
-            if self._record_frames and self._sim_step_count % self._subsample_rate == 0:
-                self.robosuite_env.step(action)
-            else:
-                self.robosuite_env.step(action, skip_render_images=True)
+            # Camera observables are refreshed on demand by
+            # get_observation(force_update=True), never by video recording.
+            self.robosuite_env.step(action, skip_render_images=True)
 
             if hasattr(self, "viser_server") and self._sim_step_count % self._subsample_rate == 0:
                 self._update_viser_server()
@@ -295,10 +294,9 @@ class RobosuiteHandoverEnv(BaseEnv):
             action = np.concatenate([robot0_action, robot1_action])
 
             # Step the environment
-            if self._record_frames and self._sim_step_count % self._subsample_rate == 0:
-                self.robosuite_env.step(action)
-            else:
-                self.robosuite_env.step(action, skip_render_images=True)
+            # Camera observables are refreshed on demand by
+            # get_observation(force_update=True), never by video recording.
+            self.robosuite_env.step(action, skip_render_images=True)
 
             if hasattr(self, "viser_server") and self._sim_step_count % self._subsample_rate == 0:
                 self._update_viser_server()
@@ -345,10 +343,9 @@ class RobosuiteHandoverEnv(BaseEnv):
             action = np.concatenate([robot0_action, robot1_action])
 
             # Step the environment
-            if self._record_frames and self._sim_step_count % self._subsample_rate == 0:
-                self.robosuite_env.step(action)
-            else:
-                self.robosuite_env.step(action, skip_render_images=True)
+            # Camera observables are refreshed on demand by
+            # get_observation(force_update=True), never by video recording.
+            self.robosuite_env.step(action, skip_render_images=True)
 
             if hasattr(self, "viser_server") and self._sim_step_count % self._subsample_rate == 0:
                 self._update_viser_server()

--- a/capx/envs/simulators/robosuite_spill_wipe.py
+++ b/capx/envs/simulators/robosuite_spill_wipe.py
@@ -166,7 +166,11 @@ class FrankaRobosuiteSpillWipeLowLevel(RobosuiteBaseEnv):
 
     def get_observation(self) -> dict[str, Any]:
         """Get observation in FrankaPickPlaceLowLevel format."""
-        robosuite_obs = self.robosuite_env._get_observations()
+        # force_update=True: camera observables are otherwise only refreshed by the
+        # occasional full robosuite step, which used to be gated on video recording.
+        # Without it, perception (SAM3/GraspNet) reuses the RGB-D from reset() and
+        # grasps stale object poses. See _do_robosuite_step in robosuite_base.py.
+        robosuite_obs = self.robosuite_env._get_observations(force_update=True)
 
         self._process_camera_observations(robosuite_obs)
 


### PR DESCRIPTION
Fixes #25.

## Problem

`--record-video` changed task outcomes, not just whether media was saved.

`_do_robosuite_step` gated robosuite's observable refresh on `_record_frames`:

```python
need_render = (self._record_frames and self._sim_step_count % self._subsample_rate == 0) \
              or hasattr(self, "viser_server")
if need_render:
    self.robosuite_env.step(sliced)
else:
    self.robosuite_env.step(sliced, skip_render_images=True)
```

`skip_render_images=True` makes robosuite skip every `_image` / `_depth` /
`_segmentation_instance` observable. The affected `get_observation()` methods
then call `_get_observations()` without `force_update=True`, so they return the
cached `_current_observed_value` instead of invoking the sensor.

With recording off — the default, and what `scripts/run_capbench_sweep.py` uses —
perception therefore reused the RGB-D captured at `reset()` for the entire
episode. Programs that re-perceive after moving an object grasped stale poses
and failed deterministically.

Physics was never affected: both branches reach `sim.step()`. The divergence is
closed-loop (stale perception -> wrong object pose -> wrong IK target).

Measured on `cube_restack`, after the program relocates the green cube and
re-queries its pose:

| | pose changes after motion? | mean \|Δx\| |
|---|---|---|
| video off | 0 / 40 paired trials | 0 m |
| video on | 40 / 40 | 0.115 m (max 0.153 m) |

## Change

- `_do_robosuite_step` no longer looks at `_record_frames`; only the viser debug
  view still forces a full step.
- The four affected simulators (`cube_lift`, `cubes`, `cubes_restack`,
  `spill_wipe`) refresh cameras on demand via `_get_observations(force_update=True)`.
- The same recording-gated branches in `robosuite_handover.py` are removed for
  consistency. That env already forced updates, so its behaviour is unchanged.

This keeps the original optimization — cameras render only when an observation is
actually requested — while guaranteeing perception sees current state.
`_record_frame()` is untouched; it uses the read-only `sim.render()`.

Not affected, and deliberately left alone: `robosuite_nut_assembly.py` and
`robosuite_handover.py` already pass `force_update=True`;
`robosuite_two_arm_lift.py` steps independently of recording; privileged (S1)
APIs read state observables, which `skip_render_images` never skips.

## Verification

`cube_restack`, 20 trials, avg reward / task completed:

| | before | after |
|---|---|---|
| `--record-video False` | 0.002 / 0 | **0.502 / 10** |
| `--record-video True` | 0.454 / 9 | **0.452 / 9** |

The two modes now agree, which is the actual correctness criterion here.

Unchanged, as expected (their oracles only perceive before motion):
`cube_lifting` 0.977 / 19, `spill_wipe` 1.000 / 20.

`tests/test_environments.py` gives identical results before and after this
change on my setup (the pre-existing failures there are unrelated —
LIBERO/Isaac deps).

## Impact on published numbers

Benchmark cells run with recording off are affected: 4 tasks x the 8
non-privileged tiers. `cube_restack` is definitively invalidated (its near-zero
vision scores were this bug, not a perception-grounding ceiling); `cube_stack`
is likely materially affected. `cube_lifting` and `spill_wipe` single-turn
oracles are not, though generated multi-turn programs that re-perceive are.
